### PR TITLE
Take advantage of bunyan, generator syntax

### DIFF
--- a/lib/koa-bunyan.js
+++ b/lib/koa-bunyan.js
@@ -7,6 +7,7 @@ module.exports = function (logger, opts) {
   var requestTimeLevel = opts.timeLimit;
 
   return function * (next) {
+    var requestTime, localLevel;
     var startTime = Date.now();
     var ctx = this;
 
@@ -15,25 +16,20 @@ module.exports = function (logger, opts) {
       url: ctx.url
     }, '[REQ]');
 
-    var done = function () {
-      var requestTime = Date.now() - startTime;
-      var localLevel = defaultLevel;
-
-      if (requestTimeLevel && requestTime > requestTimeLevel) {
-        localLevel = 'warn';
-      }
-      logger[localLevel]({
-        method: ctx.method,
-        url: ctx.originalUrl,
-        status: ctx.status,
-        dt: requestTime
-      }, '[RES]');
-    };
-
-    ctx.res.once('finish', done);
-    ctx.res.once('close', done);
-
     yield next;
+
+    requestTime = Date.now() - startTime;
+    localLevel = defaultLevel;
+
+    if (requestTimeLevel && requestTime > requestTimeLevel) {
+      localLevel = 'warn';
+    }
+    logger[localLevel]({
+      method: ctx.method,
+      url: ctx.originalUrl,
+      status: ctx.status,
+      dt: requestTime
+    }, '[RES]');
   };
 };
 


### PR DESCRIPTION
- Log object fields to enable bunyan's built-in filtering
- Uses `yield` instead of an event listener to fire response
