### PR TITLE
Support koa 2

### DIFF
--- a/lib/koa-bunyan.js
+++ b/lib/koa-bunyan.js
@@ -1,21 +1,20 @@
 'use strict';
 
-var util = require('util');
+const util = require('util');
 
 module.exports = function (logger, opts) {
   opts = opts || {};
 
-  var defaultLevel = opts.level || 'info';
-  var requestTimeLevel = opts.timeLimit;
+  const defaultLevel = opts.level || 'info';
+  const requestTimeLevel = opts.timeLimit;
 
-  return function * (next) {
-    var startTime = new Date().getTime();
-    var ctx = this;
+  return function (ctx, next) {
+    const startTime = new Date().getTime();
     logger[defaultLevel](util.format('[REQ] %s %s', ctx.method, ctx.url));
 
-    var done = function () {
-      var requestTime = new Date().getTime() - startTime;
-      var localLevel = defaultLevel;
+    const done = function () {
+      const requestTime = new Date().getTime() - startTime;
+      const localLevel = defaultLevel;
 
       if (requestTimeLevel && requestTime > requestTimeLevel) {
         localLevel = 'warn';
@@ -27,6 +26,6 @@ module.exports = function (logger, opts) {
     ctx.res.once('close', done);
 
 
-    yield next;
+    return next();
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-bunyan",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "Using node-bunyan as koa logging middleware",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
See https://github.com/koajs/koa/blob/v2.x/docs/guide.md.  I've done minimal testing; from a running instance of https://github.com/doug-wade/dougwade.io, I got the following log lines:

```
dougwade code/dougwade.io ‹master*› » node build/app.babel.js
{"name":"cia","hostname":"dougwade.rf.lan","pid":42474,"level":30,"msg":"[REQ] GET /","time":"2016-04-04T04:23:21.449Z","src":{"file":"/Users/doug.wade/code/dougwade.io/node_modules/koa-bunyan/lib/koa-bunyan.js","line":13},"v":0}
{"name":"cia","hostname":"dougwade.rf.lan","pid":42474,"level":30,"msg":"[RES] GET / (200) took 16 ms","time":"2016-04-04T04:23:21.465Z","src":{"file":"/Users/doug.wade/code/dougwade.io/node_modules/koa-bunyan/lib/koa-bunyan.js","line":22,"func":"done"},"v":0}
{"name":"cia","hostname":"dougwade.rf.lan","pid":42474,"level":30,"msg":"[REQ] GET /favicon.ico","time":"2016-04-04T04:23:21.787Z","src":{"file":"/Users/doug.wade/code/dougwade.io/node_modules/koa-bunyan/lib/koa-bunyan.js","line":13},"v":0}
{"name":"cia","hostname":"dougwade.rf.lan","pid":42474,"level":30,"msg":"[RES] GET /favicon.ico (404) took 2 ms","time":"2016-04-04T04:23:21.789Z","src":{"file":"/Users/doug.wade/code/dougwade.io/node_modules/koa-bunyan/lib/koa-bunyan.js","line":22,"func":"done"},"v":0}
```