### PR TITLE
Add ability to log request headers

### DIFF
--- a/lib/koa-bunyan.js
+++ b/lib/koa-bunyan.js
@@ -10,7 +10,7 @@ module.exports = function (logger, opts) {
 
   return function (ctx, next) {
     const startTime = new Date().getTime();
-    logger[defaultLevel](util.format('[REQ] %s %s', ctx.method, ctx.url));
+    logger[defaultLevel](requestMessage(ctx, opts.headers));
 
     const done = function () {
       const requestTime = new Date().getTime() - startTime;
@@ -29,3 +29,16 @@ module.exports = function (logger, opts) {
     return next();
   };
 };
+
+function requestMessage (ctx, headersToLog) {
+    const message = util.format('[REQ] %s %s', ctx.method, ctx.url);
+    if (headersToLog) {
+        const filteredHeaders = headersToLog.reduce((acc, cur) => {
+            const key = cur.toLowerCase();
+            acc[key] = ctx.headers[key];
+            return acc;
+        }, {});
+        return message + ' headers ' + JSON.stringify(filteredHeaders);
+    }
+    return message;
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Using node-bunyan as koa logging middleware",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "tape tests/**/*.js"
   },
   "repository": {
     "type": "git",
@@ -20,5 +20,8 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/ivpusic/koa-bunyan/issues"
+  },
+  "devDependencies": {
+    "tape": "^4.9.1"
   }
 }


### PR DESCRIPTION
Sometimes, it's useful to log the request headers, I've added the ability to do this. If you pass in you pass in a list of the header names you'd like to include, it will log them as a JSON object along with the request.